### PR TITLE
Add previous and next button for posts

### DIFF
--- a/languages/default.yml
+++ b/languages/default.yml
@@ -15,3 +15,5 @@ search: Search
 type_to_search: Type to search...
 categories: Categories
 tags: Tags
+next_post: Next
+prev_post: Previous

--- a/languages/zh-cn.yml
+++ b/languages/zh-cn.yml
@@ -15,3 +15,5 @@ search: 搜索
 type_to_search: 键入以搜索...
 categories: 分类
 tags: 标签
+next_post: 下一篇
+prev_post: 上一篇

--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -54,6 +54,29 @@
     </div>
     <% } %>
 
+    <div class="container post-prev-next">
+        <% if (page.prev) { %>
+        <a href="<%= url_for(page.prev.path) %>" class="next">
+            <div>
+                <div class="text">
+                    <p class="label"><%= __('next_post') %></p>
+                    <h3 class="title"><%= page.prev.title %></h3>
+                </div>
+            </div>
+        </a>
+        <% } else { %><a class="next"></a><% } %>
+        <% if (page.next) { %>
+        <a href="<%= url_for(page.next.path) %>" class="prev">
+            <div>
+                <div class="text">
+                    <p class="label"><%= __('prev_post') %></p>
+                    <h3 class="title"><%= page.next.title %></>
+                </div>
+            </div>
+        </a>
+        <% } else { %><a class="prev"></a><% } %>
+    </div>
+
     <% if (!page.no_comments) { %>
         <% if (config.waline) { %>
         <div class="container">

--- a/source/css/post.css
+++ b/source/css/post.css
@@ -310,3 +310,45 @@ body[data-color-scheme="dark"] .tags .icon {
 .content > h6 {
   font-size: 14px;
 }
+
+.post-prev-next {
+  display: flex;
+  justify-content: space-between;
+}
+
+.post-prev-next > a {
+  width: 50%;
+  color: var(--black-4);
+  text-decoration: none;
+}
+
+.post-prev-next > a:hover {
+  color: var(--black-2);
+}
+
+.post-prev-next > a > div {
+  display: flex;
+}
+
+.post-prev-next .text {
+  display: flex;
+  flex-direction: column;
+}
+
+.post-prev-next .prev > div {
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.post-prev-next .prev .text {
+  align-items: flex-end;
+}
+
+.post-prev-next .text * {
+  margin: 0;
+}
+
+.post-prev-next .text .label {
+  margin-bottom: 4px;
+  color: var(--grey);
+}


### PR DESCRIPTION
Adds previous and next button for every post.

![Screen Shot of the buttons](https://user-images.githubusercontent.com/47271684/197380719-3d0960f9-9366-4eda-9572-6d05f20eec6f.png)

This is inspired by [jonie-ritie/blog_us/themes/cupertino/layout/post.ejs#L69](https://github.com/jonie-ritie/blog_us/blob/89ea6a6e660e9087e6295b914ed595ad8cae589f/themes/cupertino/layout/post.ejs#L69), Big thanks to @jonie-ritie!
