### PR TITLE
feat: change toc style

### DIFF
--- a/source/css/toc.css
+++ b/source/css/toc.css
@@ -1,5 +1,7 @@
 .toc > p {
   margin: 0;
+  border-left: 1px solid var(--border-color);
+  transition: color 0.2s, border-color 0.2s;
 }
 
 .toc > p > a {
@@ -8,13 +10,35 @@
   display: inline-block;
   padding: 8px 0;
   padding-left: 12px;
-  border-left: 1px solid var(--border-color);
-  transition: color 0.2s, border-color 0.2s;
 }
 
-.toc > p > a:hover,
-.toc > p > a:focus-visible {
+.toc > p:hover,
+.toc > p:focus-visible {
   color: var(--black);
   text-decoration: none;
   border-color: var(--black-2);
+}
+
+.toc .pageHeaderTocHeadingContainerPh1 {
+  padding-left: 0;
+}
+
+.toc .pageHeaderTocHeadingContainerPh2 {
+  padding-left: 1em;
+}
+
+.toc .pageHeaderTocHeadingContainerPh3 {
+  padding-left: 2em;
+}
+
+.toc .pageHeaderTocHeadingContainerPh4 {
+  padding-left: 3em;
+}
+
+.toc .pageHeaderTocHeadingContainerPh5 {
+  padding-left: 4em;
+}
+
+.toc .pageHeaderTocHeadingContainerPh6 {
+  padding-left: 5em;
 }

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -132,7 +132,8 @@
         headings.forEach((heading) => {
             source.push({
                 html: heading.innerHTML,
-                href: heading.getElementsByClassName('headerlink')[0].attributes['href'].value
+                href: heading.getElementsByClassName('headerlink')[0].attributes['href'].value,
+                level: heading.tagName
             })
         })
 
@@ -144,6 +145,7 @@
             link.href = source[i].href
             link.innerHTML = source[i].html
             link.removeChild(link.getElementsByClassName('headerlink')[0])
+            item.className = 'pageHeaderTocHeadingContainerP' + source[i].level.toLowerCase()
             item.appendChild(link)
             toc.appendChild(item)
         }


### PR DESCRIPTION
Hi, I recently find your theme and it's quite beautiful. However, I notice that your theme doesn't make a difference in too between different levels of headings. I'm not sure whether it's because of your design or anything, but I kinda need it. Therefore, I change some of your code, and I'm wondering whether you'll need it. 
Now toc looks like this: 
<img width="442" alt="image" src="https://user-images.githubusercontent.com/89848201/236197697-fb3a50e5-98e2-464d-b1de-a097280ffd45.png">
**Please notice** that I use a quite long class name in `source/js/main.js` to differ different levels of headings, you can  change it according to your naming habits.

你好，我最近发现了您的主题。我非常喜欢它的样式，但是我也注意到您的主题没有对不同级的标题作出区分。我不确定这是由于您设计上的考量或是其他原因，但我个人比较需要这个功能。因而，我修改了部分您的代码，并好奇您是否需要这一改变。
目前目录的样式如下图：
<img width="442" alt="image" src="https://user-images.githubusercontent.com/89848201/236197697-fb3a50e5-98e2-464d-b1de-a097280ffd45.png">
**请注意**，为了方便调整样式因而在`source/js/main.js`中我使用了一个较长的类名，您可以根据项目命名风格来调整它。