### PR TITLE
Fix inappropriate list margin in the quote

### DIFF
--- a/source/css/post.css
+++ b/source/css/post.css
@@ -170,12 +170,13 @@ hr,
 .content ol {
   padding: 0 16px;
   padding-left: 32px;
+  margin-block-start: 1em;
   max-width: calc(800px - 16px * 2);
 }
 
 .content ul *,
 .content ol * {
-  padding: 0;
+  /*padding: 0;*/
 }
 
 .content blockquote {

--- a/source/css/post.css
+++ b/source/css/post.css
@@ -171,12 +171,8 @@ hr,
   padding: 0 16px;
   padding-left: 32px;
   margin-block-start: 1em;
+  margin-block-end: 1em;
   max-width: calc(800px - 16px * 2);
-}
-
-.content ul *,
-.content ol * {
-  /*padding: 0;*/
 }
 
 .content blockquote {


### PR DESCRIPTION
Fix for inappropriate list margin in the quote.

Before fix:
<img width="745" alt="截屏2024-01-06 下午7 14 49" src="https://github.com/MrWillCom/hexo-theme-cupertino/assets/68026794/85cc9951-8753-4a99-8b3c-38f674f59b2e">


After fix:
<img width="751" alt="截屏2024-01-06 下午7 36 44" src="https://github.com/MrWillCom/hexo-theme-cupertino/assets/68026794/311de788-5872-4e67-ac58-18bf2227262b">
